### PR TITLE
Added issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a bug you've encountered
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Description**
+<!-- Provide a clear and concise description of what the bug is (provide screenshots/gifs if possible) -->
+...
+
+**Reproduction Steps**
+<!-- Provide steps to reproduce the bug (remember to list the compile and execution steps) -->
+...
+
+**Technical Details**
+ - OS Version: [e.g. `Ubuntu-20.04.2.0`]
+ - Project Version: [e.g. `v0.1.0`]
+
+**Additional Comments**
+<!-- Add any other information or context about the problem here (delete this section if empty) -->
+...

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,12 @@
+---
+name: Feature
+about: Describe a potential new feature
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Description**
+<!-- A clear and concise description of what the feature should be (and if applicable, what problem it solves for you) -->
+...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Description
+<!-- Provide a brief description of what this PR does and how it can be tested below (provide screenshots/gifs if relevant) -->
+...
+
+<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
+### The PR has been...
+- [ ] provided a reasonable name that is not just the branch name (e.g "Added Vulkan render delegate")
+- [ ] linked to its related issue
+- [ ] assigned a reviewer from the team
+- [ ] labelled appropriately
+
+### The code has been...
+- [ ] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
+- [ ] pulled to the reviewer's machine and reasonably tested
+
+<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->


### PR DESCRIPTION
This PR adds basic issue templates to the repo for both features and bug reports. While features only require descriptions, bug reports also require reproduction steps, technical details (currently just OS version and project version), and allow for additional comments. Both templates will automatically tag created issues appropriately for their respective purposes.