### PR TITLE
Fixed faulty SPIRV-Tools Version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: update apt
-      run: |
-        sudo apt update
-        sudo apt-get update
+      run: sudo apt-get update
 
     - name: install vulkan dependencies
       run: sudo apt install git build-essential libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: update apt
-      run: sudo apt update
+      run: |
+        sudo apt update
+        sudo apt-get update
 
     - name: install vulkan dependencies
       run: sudo apt install git build-essential libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: update apt
-      run: sudo apt update
+      run: sudo apt-get update
 
     - name: install vulkan dependencies
       run: sudo apt install git build-essential libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -165,6 +165,8 @@ EXIT /B 0
 
     CALL :UpdateSubmodule vulkan\SPIRV-Tools
 
+    CALL :CheckoutTags %VULKAN_VENDOR_DIR%\SPIRV-Tools 2022.4
+
     set BUILD_DIR=%VULKAN_VENDOR_DIR%\SPIRV-Tools\build
 
     mkdir %BUILD_DIR%

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -13,6 +13,7 @@ setlocal enableextensions
 set ROOT_DIR=%cd%
 
 set VULKAN_VERSION=1.3.211
+set SPIRV_VERSION=2022.4
 set GENERATOR=MinGW Makefiles
 set VENDOR_DIR=%ROOT_DIR%\vendor
 
@@ -165,7 +166,7 @@ EXIT /B 0
 
     CALL :UpdateSubmodule vulkan\SPIRV-Tools
 
-    CALL :CheckoutTags %VULKAN_VENDOR_DIR%\SPIRV-Tools 2022.4
+    CALL :CheckoutTags %VULKAN_VENDOR_DIR%\SPIRV-Tools %SPIRV_VERSION%
 
     set BUILD_DIR=%VULKAN_VENDOR_DIR%\SPIRV-Tools\build
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,6 +26,7 @@ fi
 
 # Set setup details
 VULKAN_VERSION="1.3.211"
+SPIRV_VERSION="2022.4"
 GENERATOR="Unix Makefiles"
 VENDOR_DIR="${ROOT_DIR}/vendor"
 
@@ -156,7 +157,7 @@ setup_spirv_headers() {
 setup_spirv_tools() {
     echo "Cloning SPIRV Tools..."
     update_submodules vulkan/SPIRV-Tools
-    checkout_tags "${VULKAN_VENDOR_DIR}"/SPIRV-Tools "2022.4"
+    checkout_tags "${VULKAN_VENDOR_DIR}"/SPIRV-Tools "$SPIRV_VERSION"
 
     echo "Setting up SPIRV Tools..."
     local BUILD_DIR="${VULKAN_VENDOR_DIR}"/SPIRV-Tools/build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -156,6 +156,7 @@ setup_spirv_headers() {
 setup_spirv_tools() {
     echo "Cloning SPIRV Tools..."
     update_submodules vulkan/SPIRV-Tools
+    checkout_tags "${VULKAN_VENDOR_DIR}"/SPIRV-Tools "2022.4"
 
     echo "Setting up SPIRV Tools..."
     local BUILD_DIR="${VULKAN_VENDOR_DIR}"/SPIRV-Tools/build


### PR DESCRIPTION
### Description
Previously we were building an older version of SPIRV-Tools which was using `sprintf`. This has recently been deprecated by xcode and causes build failures on MacOS. This PR updates the version of SPIRV-Tools and ensures that the project can still build. 

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added Vulkan render delegate")
- [x] linked to its related issue
- [x] assigned a reviewer from the team
- [x] labelled appropriately

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] pulled to the reviewer's machine and reasonably tested

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
