### PR TITLE
Added the FColour and IColour types

### DIFF
--- a/engine/core/TransitionAdapter.cpp
+++ b/engine/core/TransitionAdapter.cpp
@@ -47,12 +47,12 @@ BoundingBox FromBoundedBox(BoundedBox bbox)
     return {FromVec3(bbox.min), FromVec3(bbox.max)};
 }
 
-Colour ToColour(Color color)
+IColour ToColour(Color color)
 {
     return {color.r, color.g, color.b, color.a};
 }
 
-Color FromColour(Colour color)
+Color FromColour(IColour color)
 {
     return {(unsigned char) color.r,
             (unsigned char) color.g,

--- a/engine/core/TransitionAdapter.h
+++ b/engine/core/TransitionAdapter.h
@@ -33,9 +33,9 @@ BoundedBox ToBoundedBox(BoundingBox bbox);
 
 BoundingBox FromBoundedBox(BoundedBox bbox);
 
-Colour ToColour(Color color);
+IColour ToColour(Color color);
 
-Color FromColour(Colour color);
+Color FromColour(IColour color);
 } // namespace Siege
 
 #endif // SIEGE_ENGINE_TRANSITIONADAPTER_H

--- a/engine/core/render/RenderSystem.cpp
+++ b/engine/core/render/RenderSystem.cpp
@@ -62,12 +62,12 @@ void RenderSystem::Remove(Entity* entity)
     if (it != renderItems.end()) renderItems.erase(it);
 }
 
-void RenderSystem::DrawText2D(const String& text, int posX, int posY, int fontSize, Colour color)
+void RenderSystem::DrawText2D(const String& text, int posX, int posY, int fontSize, IColour color)
 {
     DrawText(text, posX, posY, fontSize, FromColour(color));
 }
 
-void RenderSystem::DrawRectangle2D(int posX, int posY, int width, int height, Colour color)
+void RenderSystem::DrawRectangle2D(int posX, int posY, int width, int height, IColour color)
 {
     DrawRectangle(posX, posY, width, height, FromColour(color));
 }

--- a/engine/core/render/RenderSystem.h
+++ b/engine/core/render/RenderSystem.h
@@ -51,9 +51,9 @@ public:
 
     void DrawFrame();
 
-    void DrawText2D(const String& text, int posX, int posY, int fontSize, Colour color);
+    void DrawText2D(const String& text, int posX, int posY, int fontSize, IColour color);
 
-    void DrawRectangle2D(int posX, int posY, int width, int height, Colour color);
+    void DrawRectangle2D(int posX, int posY, int width, int height, IColour color);
 
 private:
 

--- a/engine/core/render/Window.h
+++ b/engine/core/render/Window.h
@@ -46,7 +46,7 @@ private:
 
     // Private fields
 
-    Colour backgroundColour;
+    IColour backgroundColour;
 
     static float deltaTime;
 };

--- a/engine/render/renderer/lights/PointLight.cpp
+++ b/engine/render/renderer/lights/PointLight.cpp
@@ -13,7 +13,7 @@ namespace Siege
 
 PointLight::PointLight() : PointLight(Vec3::Zero, {1.0f, 1.0f, 1.0f, 0.2f}, {1.f, 1.f, 1.f, .2f}) {}
 
-PointLight::PointLight(Vec3 position, Vec4 color, Vec4 ambientColor) :
+PointLight::PointLight(Vec3 position, FColour color, FColour ambientColor) :
     lightData {color, ambientColor, position}
 {}
 

--- a/engine/render/renderer/lights/PointLight.h
+++ b/engine/render/renderer/lights/PointLight.h
@@ -21,13 +21,13 @@ public:
 
     struct Data
     {
-        Vec4 lightColor = {1.f, 1.f, 1.f, 0.2f};
-        alignas(16) Vec4 ambientLightColor = {1.f, 1.f, 1.f, .02f};
+        FColour lightColor = {1.f, 1.f, 1.f, 0.2f};
+        alignas(16) FColour ambientLightColor = {1.f, 1.f, 1.f, .02f};
         alignas(16) Vec3 position = Vec3::Zero;
     };
 
     PointLight();
-    PointLight(Vec3 position, Vec4 color, Vec4 ambientColor);
+    PointLight(Vec3 position, FColour color, FColour ambientColor);
     ~PointLight();
 
     Data& GetLightData()
@@ -42,11 +42,11 @@ public:
     {
         lightData.position = position;
     }
-    void SetColor(Vec4 color)
+    void SetColor(FColour color)
     {
         lightData.lightColor = color;
     }
-    void SetAmbientColor(Vec4 ambientColor)
+    void SetAmbientColor(FColour ambientColor)
     {
         lightData.ambientLightColor = ambientColor;
     }

--- a/engine/render/renderer/mesh/Mesh.h
+++ b/engine/render/renderer/mesh/Mesh.h
@@ -9,6 +9,8 @@
 #ifndef SIEGE_ENGINE_MESH_H
 #define SIEGE_ENGINE_MESH_H
 
+#include <utils/Colour.h>
+
 #include "../Core.h"
 #include "../buffer/Buffer.h"
 #include "render/renderer/platform/vulkan/CommandBuffer.h"
@@ -18,7 +20,7 @@ namespace Siege
 struct Vertex
 {
     Vec3 position;
-    Vec3 color;
+    FColour color;
     Vec3 normal;
     Vec2 uv;
 };
@@ -26,7 +28,7 @@ struct Vertex
 struct Vertex2D
 {
     Vec2 position;
-    Vec3 color;
+    FColour color;
 };
 
 struct BillboardVertex

--- a/engine/render/renderer/model/Model.cpp
+++ b/engine/render/renderer/model/Model.cpp
@@ -120,9 +120,10 @@ void Model::LoadModelFromFile(const String& filePath)
                                         attrib.vertices[3 * index.vertex_index + 1],
                                         attrib.vertices[3 * index.vertex_index + 2]};
 
-                vertex.color = Vec3 {attrib.colors[3 * index.vertex_index + 0],
-                                     attrib.colors[3 * index.vertex_index + 1],
-                                     attrib.colors[3 * index.vertex_index + 2]};
+                vertex.color = FColour {attrib.colors[3 * index.vertex_index + 0],
+                                        attrib.colors[3 * index.vertex_index + 1],
+                                        attrib.colors[3 * index.vertex_index + 2],
+                                        1.f};
             }
 
             if (index.normal_index >= 0)

--- a/engine/render/renderer/renderer/BillboardRenderer.cpp
+++ b/engine/render/renderer/renderer/BillboardRenderer.cpp
@@ -45,12 +45,15 @@ void BillboardRenderer::Destroy()
     billboardModel.DestroyModel();
 }
 
-void BillboardRenderer::DrawBillboard(const Vec3& position, const Vec2& scale, const Vec4& colour)
+void BillboardRenderer::DrawBillboard(const Vec3& position,
+                                      const Vec2& scale,
+                                      const IColour& colour)
 {
-    vertices.Append({{1.f, 1.f, 1.f}, colour});
-    vertices.Append({{1.f, -1.f, 1.f}, colour});
-    vertices.Append({{-1.f, -1.f, 1.f}, colour});
-    vertices.Append({{-1.f, 1.f, 1.f}, colour});
+    auto fColour = ToFColour(colour);
+    vertices.Append({{1.f, 1.f, 1.f}, fColour});
+    vertices.Append({{1.f, -1.f, 1.f}, fColour});
+    vertices.Append({{-1.f, -1.f, 1.f}, fColour});
+    vertices.Append({{-1.f, 1.f, 1.f}, fColour});
 
     // Pattern: 0, 1, 3, 1, 2, 3
     indices.Append(vertices.Count() - 4);

--- a/engine/render/renderer/renderer/BillboardRenderer.h
+++ b/engine/render/renderer/renderer/BillboardRenderer.h
@@ -9,6 +9,8 @@
 #ifndef SIEGE_ENGINE_BILLBOARD_RENDERER_H
 #define SIEGE_ENGINE_BILLBOARD_RENDERER_H
 
+#include <utils/Colour.h>
+
 #include "../Core.h"
 #include "../model/Model.h"
 
@@ -24,7 +26,7 @@ public:
     void Initialise(const String& globalDataAttributeName, const uint64_t& globalDataSize);
     void Destroy();
 
-    void DrawBillboard(const Vec3& position, const Vec2& scale, const Vec4& colour);
+    void DrawBillboard(const Vec3& position, const Vec2& scale, const IColour& colour);
 
     void Render(Vulkan::CommandBuffer& commandBuffer,
                 const uint64_t& globalDataSize,
@@ -39,7 +41,7 @@ private:
     struct BillboardVertex
     {
         Vec3 position;
-        Vec4 colour;
+        FColour colour;
     };
 
     struct BillboardUBO

--- a/engine/render/renderer/renderer/DebugRenderer3D.cpp
+++ b/engine/render/renderer/renderer/DebugRenderer3D.cpp
@@ -47,10 +47,11 @@ void DebugRenderer3D::RecreateMaterials()
 }
 
 // Wire primitives
-void DebugRenderer3D::DrawLine(const Vec3& origin, const Vec3& destination, const Vec4& colour)
+void DebugRenderer3D::DrawLine(const Vec3& origin, const Vec3& destination, const IColour& colour)
 {
-    lines.Append({origin, colour});
-    lines.Append({destination, colour});
+    auto fColour = ToFColour(colour);
+    lines.Append({origin, fColour});
+    lines.Append({destination, fColour});
 }
 
 void DebugRenderer3D::Flush()

--- a/engine/render/renderer/renderer/DebugRenderer3D.h
+++ b/engine/render/renderer/renderer/DebugRenderer3D.h
@@ -25,9 +25,8 @@ public:
     void Destroy();
 
     // Wire primitives
-    void DrawLine(const Siege::Vec3& origin,
-                  const Siege::Vec3& destination,
-                  const Siege::Vec4& colour);
+    void DrawLine(const Vec3& origin, const Vec3& destination, const IColour& colour);
+    void DrawCube(const Vec3& position, const Vec3& rotation, const Vec3& scale);
 
     void Render(Vulkan::CommandBuffer& commandBuffer,
                 const uint64_t& globalDataSize,
@@ -42,7 +41,7 @@ private:
     struct LineVertex
     {
         Vec3 position;
-        Vec4 colour;
+        FColour colour;
     };
 
     void RenderLines(Vulkan::CommandBuffer& commandBuffer,

--- a/engine/render/renderer/renderer/LightRenderer.cpp
+++ b/engine/render/renderer/renderer/LightRenderer.cpp
@@ -39,8 +39,8 @@ void LightRenderer::Destroy()
 
 void LightRenderer::DrawPointLight(const Vec3& position,
                                    float radius,
-                                   const Vec4& colour,
-                                   const Vec4& ambientColor)
+                                   const IColour& colour,
+                                   const IColour& ambientColor)
 {
     pointLightVertices.Append({1.f, 1.f});
     pointLightVertices.Append({1.f, -1.f});

--- a/engine/render/renderer/renderer/LightRenderer.h
+++ b/engine/render/renderer/renderer/LightRenderer.h
@@ -24,8 +24,8 @@ public:
 
     void DrawPointLight(const Vec3& position,
                         float radius,
-                        const Vec4& colour,
-                        const Vec4& ambientColor);
+                        const IColour& colour,
+                        const IColour& ambientColor);
 
     void Render(Vulkan::CommandBuffer& commandBuffer,
                 const uint64_t& globalDataSize,

--- a/engine/render/renderer/renderer/Renderer3D.cpp
+++ b/engine/render/renderer/renderer/Renderer3D.cpp
@@ -39,7 +39,7 @@ void Renderer3D::Initialise()
         Vulkan::Shader::Builder().FromFragmentShader("assets/shaders/grid.frag.spv").Build());
 }
 
-void Renderer3D::DrawBillboard(const Vec3& position, const Vec2& scale, const Vec4& colour)
+void Renderer3D::DrawBillboard(const Vec3& position, const Vec2& scale, const IColour& colour)
 {
     billboardRenderer.DrawBillboard(position, scale, colour);
 }
@@ -62,12 +62,12 @@ void Renderer3D::DrawModel(Model* model, const Vec3& position)
     DrawModel(model, position, Vec3::One, Vec3::Zero);
 }
 
-void Renderer3D::DrawPointLight(const Siege::Vec3& position,
-                                const float& radius,
-                                const Siege::Vec4& colour,
-                                const Siege::Vec4& ambientColor)
+void Renderer3D::DrawPointLight(const Vec3& position,
+                                float radius,
+                                const IColour& colour,
+                                const IColour& ambientColor)
 {
-    global3DData.lightData = {colour, ambientColor, position};
+    global3DData.lightData = {ToFColour(colour), ToFColour(ambientColor), position};
 
     lightRenderer.DrawPointLight(position, 0.05f, colour, ambientColor);
 }
@@ -87,7 +87,7 @@ void Renderer3D::Render(Vulkan::CommandBuffer& commandBuffer, const CameraData& 
 #endif
 }
 
-void Renderer3D::DrawLine(const Vec3& origin, const Vec3& destination, const Vec4& colour)
+void Renderer3D::DrawLine(const Vec3& origin, const Vec3& destination, const IColour& colour)
 {
     debugRenderer.DrawLine(origin, destination, colour);
 }

--- a/engine/render/renderer/renderer/Renderer3D.h
+++ b/engine/render/renderer/renderer/Renderer3D.h
@@ -41,18 +41,16 @@ public:
     static void DrawModel(Model* model, const Vec3& position, const Vec3& scale);
     static void DrawModel(Model* model, const Vec3& position);
 
-    static void DrawBillboard(const Vec3& position, const Vec2& scale, const Vec4& colour);
+    static void DrawBillboard(const Vec3& position, const Vec2& scale, const IColour& colour);
 
     // Debug rendering
     // TODO(Aryeh): Move this to it's own renderer module?
-    static void DrawLine(const Siege::Vec3& origin,
-                         const Siege::Vec3& destination,
-                         const Siege::Vec4& colour);
+    static void DrawLine(const Vec3& origin, const Vec3& destination, const IColour& colour);
 
-    static void DrawPointLight(const Siege::Vec3& position,
-                               const float& radius,
-                               const Siege::Vec4& colour,
-                               const Siege::Vec4& ambientColor);
+    static void DrawPointLight(const Vec3& position,
+                               float radius,
+                               const IColour& colour,
+                               const IColour& ambientColor);
 
     static void RecreateMaterials();
 

--- a/engine/utils/Colour.cpp
+++ b/engine/utils/Colour.cpp
@@ -10,11 +10,4 @@
 
 namespace Siege
 {
-// Define static members
-const Colour Colour::Black = {0, 0, 0, 255};
-const Colour Colour::White = {255, 255, 255, 255};
-const Colour Colour::Red = {230, 41, 55, 255};
-const Colour Colour::Green = {0, 228, 48, 255};
-const Colour Colour::Blue = {0, 121, 241, 255};
-const Colour Colour::Pink = {255, 109, 194, 255};
 } // namespace Siege

--- a/engine/utils/Colour.cpp
+++ b/engine/utils/Colour.cpp
@@ -6,5 +6,14 @@
 //     https://opensource.org/licenses/Zlib
 //
 
+#include "Colour.h"
+
 namespace Siege
-{} // namespace Siege
+{
+Colour<uint8_t>::Colour(const FColour& other) :
+    r {static_cast<uint8_t>(other.r)},
+    g {static_cast<uint8_t>(other.g)},
+    b {static_cast<uint8_t>(other.b)},
+    a {static_cast<uint8_t>(other.a)}
+{}
+} // namespace Siege

--- a/engine/utils/Colour.cpp
+++ b/engine/utils/Colour.cpp
@@ -6,8 +6,5 @@
 //     https://opensource.org/licenses/Zlib
 //
 
-#include "Colour.h"
-
 namespace Siege
-{
-} // namespace Siege
+{} // namespace Siege

--- a/engine/utils/Colour.h
+++ b/engine/utils/Colour.h
@@ -19,50 +19,79 @@ namespace Siege
 template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
 struct Colour;
 
-typedef Colour<float> FColour;
-typedef Colour<uint8_t> IColour;
+typedef struct Colour<float> FColour;
+typedef struct Colour<uint8_t> IColour;
 
-template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type*>
-struct Colour
+/**
+ * An 8-bit unsigned integer based Colour struct. Every colour channel in this struct ranges between
+ * 0 and 255, with 255 being the brightest colour channel
+ */
+template<>
+struct Colour<uint8_t>
 {
+    // Static constants
+
+    static const IColour White;
+    static const IColour Black;
+    static const IColour Red;
+    static const IColour Green;
+    static const IColour Blue;
+    static const IColour Pink;
+
     // 'Structors
 
-    inline constexpr Colour(T red = 0, T green = 0, T blue = 0, T alpha = 0) :
+    /**
+     * The base constructor for the colour
+     * @param red the red channel value
+     * @param green the green channel value
+     * @param blue the blue channel value
+     * @param alpha the alpha channel value
+     */
+    inline constexpr Colour(uint8_t red = 0,
+                            uint8_t green = 0,
+                            uint8_t blue = 0,
+                            uint8_t alpha = 0) :
         r {red},
         g {green},
         b {blue},
         a {alpha}
     {}
 
-    inline constexpr Colour(const FColour& other) :
-        r {static_cast<T>(other.r)},
-        g {static_cast<T>(other.g)},
-        b {static_cast<T>(other.b)},
-        a {static_cast<T>(other.a)}
-    {}
+    /**
+     * A conversion from a float-based Colour struct.
+     * @warn this does not convert the normalised values of an FColour into an IColour. Please be
+     * careful with how you convert between these two. If you want a function which converts the
+     * normalised value of the FColour to a 0 - 255 range, please use the ToIColour() method
+     * @param other
+     */
+    Colour(const FColour& other);
 
+    /**
+     * A copy constructor for the IColour struct
+     * @param other the IColour to copy over
+     */
     inline constexpr Colour(const IColour& other) :
-        r {static_cast<T>(other.r)},
-        g {static_cast<T>(other.g)},
-        b {static_cast<T>(other.b)},
-        a {static_cast<T>(other.a)}
+        r {other.r},
+        g {other.g},
+        b {other.b},
+        a {other.a}
     {}
 
-    inline constexpr bool operator==(const FColour& other) const
-    {
-        return r == other.r && g == other.g && b == other.b && a == other.a;
-    }
-
+    /**
+     * An equality operator
+     * @param other the Colour to compare to
+     * @return true of they are the same, false if they aren't
+     */
     inline constexpr bool operator==(const IColour& other) const
     {
         return r == other.r && g == other.g && b == other.b && a == other.a;
     }
 
-    inline constexpr bool operator!=(const FColour& other) const
-    {
-        return r == other.r || g == other.g || b == other.b || a == other.a;
-    }
-
+    /**
+     * An in-equality operator
+     * @param other the Colour to compare to
+     * @return false of they are the same, true if they aren't
+     */
     inline constexpr bool operator!=(const IColour& other) const
     {
         return r == other.r || g == other.g || b == other.b || a == other.a;
@@ -70,32 +99,118 @@ struct Colour
 
     // Public members
 
-    T r {0};
-    T g {0};
-    T b {0};
-    T a {0};
+    uint8_t r {0};
+    uint8_t g {0};
+    uint8_t b {0};
+    uint8_t a {0};
+};
+
+inline constexpr IColour IColour::White {255, 255, 255, 255};
+inline constexpr IColour IColour::Black {0, 0, 0, 255};
+inline constexpr IColour IColour::Red {255, 0, 0, 255};
+inline constexpr IColour IColour::Green {0, 255, 0, 255};
+inline constexpr IColour IColour::Blue {0, 0, 255, 255};
+inline constexpr IColour IColour::Pink {255, 109, 194, 255};
+
+template<>
+struct Colour<float>
+{
+    // Static constants
+
+    static const FColour White;
+    static const FColour Black;
+    static const FColour Red;
+    static const FColour Green;
+    static const FColour Blue;
+    static const FColour Pink;
+
+    /**
+     * The base constructor for the colour
+     * @param red the red channel value
+     * @param green the green channel value
+     * @param blue the blue channel value
+     * @param alpha the alpha channel value
+     */
+    inline constexpr Colour(float red = 0.f,
+                            float green = 0.f,
+                            float blue = 0.f,
+                            float alpha = 0.f) :
+        r {red},
+        g {green},
+        b {blue},
+        a {alpha}
+    {}
+
+    /**
+     * A copy constructor for the FColour struct
+     * @param other the FColour to copy over
+     */
+    inline constexpr Colour(const FColour& other) :
+        r {other.r},
+        g {other.g},
+        b {other.b},
+        a {other.a}
+    {}
+
+    /**
+     * A conversion from an 8-bit unsigned integer based Colour struct.
+     * @warn this does not convert the normalised values of an FColour into an IColour. Please be
+     * careful with how you convert between these two. If you want a function which converts the
+     * normalised value of the FColour to a 0 - 255 range, please use the ToFColour() method
+     * @param other
+     */
+    inline constexpr Colour(const IColour& other) :
+        r {static_cast<float>(other.r)},
+        g {static_cast<float>(other.g)},
+        b {static_cast<float>(other.b)},
+        a {static_cast<float>(other.a)}
+    {}
+
+    /**
+     * An equality operator
+     * @param other the Colour to compare to
+     * @return true of they are the same, false if they aren't
+     */
+    inline constexpr bool operator==(const FColour& other) const
+    {
+        return r == other.r && g == other.g && b == other.b && a == other.a;
+    }
+
+    /**
+     * An in-equality operator
+     * @param other the Colour to compare to
+     * @return false of they are the same, true if they aren't
+     */
+    inline constexpr bool operator!=(const FColour& other) const
+    {
+        return r == other.r || g == other.g || b == other.b || a == other.a;
+    }
+
+    float r {0.f};
+    float g {0.f};
+    float b {0.f};
+    float a {0.f};
 };
 
 // FColour constants
 
-inline constexpr FColour FWhite = {1.f, 1.f, 1.f, 1.f};
-inline constexpr FColour FBlack = {0.f, 0.f, 0.f, 1.f};
-inline constexpr FColour FRed = {1.f, 0.f, 0.f, 1.f};
-inline constexpr FColour FGreen = {0.f, 1.f, 0.f, 1.f};
-inline constexpr FColour FBlue = {0.f, 0.f, 1.f, 1.f};
-inline constexpr FColour FPink = {1.f, 0.427450980392, 0.760784313725, 1.f};
-
-// IColour constants
-
-inline constexpr IColour IWhite = {255, 255, 255, 255};
-inline constexpr IColour IBlack = {0, 0, 0, 255};
-inline constexpr IColour IRed = {255, 0, 0, 255};
-inline constexpr IColour IGreen = {0, 255, 0, 255};
-inline constexpr IColour IBlue = {0, 0, 255, 255};
-inline constexpr IColour IPink = {255, 109, 194, 255};
+inline constexpr FColour FColour::White = {1.f, 1.f, 1.f, 1.f};
+inline constexpr FColour FColour::Black = {0.f, 0.f, 0.f, 1.f};
+inline constexpr FColour FColour::Red = {1.f, 0.f, 0.f, 1.f};
+inline constexpr FColour FColour::Green = {0.f, 1.f, 0.f, 1.f};
+inline constexpr FColour FColour::Blue = {0.f, 0.f, 1.f, 1.f};
+inline constexpr FColour FColour::Pink = {1.f, 0.427450980392, 0.760784313725, 1.f};
 
 // Conversion functions
 
+/**
+ * Converts an IColour to an FColour. This function is different to the standard constructors in
+ * that it takes the 0 to 255 range of the IColour and normalises it between 0 and 1 (as a float).
+ * This Method is useful for converting 8 bit Colours to float colours in an accurate manner. This
+ * is the recommended approach for converting the two colours
+ * @param other the IColour to compare
+ * @return an FColour with the normalised values
+ */
 inline constexpr FColour ToFColour(const IColour& other)
 {
     return {(static_cast<float>(other.r) - 0.f) / (255.f - 0.f),
@@ -104,6 +219,14 @@ inline constexpr FColour ToFColour(const IColour& other)
             (static_cast<float>(other.a) - 0.f) / (255.f - 0.f)};
 }
 
+/**
+ * Converts an FColour to an IColour. This function is different to the standard constructors in
+ * that it takes the 0 to 1 range of the FColour and expands it between 0 and 255 (as a uint8_t).
+ * This Method is useful for converting 8 bit Colours to float colours in an accurate manner. This
+ * is the recommended approach for converting the two colours
+ * @param other the FColour to convert
+ * @return an IColour with the expanded values
+ */
 inline constexpr FColour ToIColour(const FColour& other)
 {
     return {static_cast<float>(other.r * 255),
@@ -117,7 +240,7 @@ inline constexpr FColour ToIColour(const FColour& other)
 namespace std
 {
 template<>
-struct ::std::hash<Siege::FColour>
+struct hash<Siege::FColour>
 {
     size_t operator()(const Siege::FColour& colour) const
     {
@@ -128,7 +251,7 @@ struct ::std::hash<Siege::FColour>
 };
 
 template<>
-struct ::std::hash<Siege::IColour>
+struct hash<Siege::IColour>
 {
     size_t operator()(const Siege::IColour& colour) const
     {

--- a/engine/utils/Colour.h
+++ b/engine/utils/Colour.h
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "Hash.h"
+
 namespace Siege
 {
 template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
@@ -43,8 +45,28 @@ struct Colour
         r {static_cast<T>(other.r)},
         g {static_cast<T>(other.g)},
         b {static_cast<T>(other.b)},
-        a {static_cast<T>(other.a )}
+        a {static_cast<T>(other.a)}
     {}
+
+    inline constexpr bool operator==(const FColour& other) const
+    {
+        return r == other.r && g == other.g && b == other.b && a == other.a;
+    }
+
+    inline constexpr bool operator==(const IColour& other) const
+    {
+        return r == other.r && g == other.g && b == other.b && a == other.a;
+    }
+
+    inline constexpr bool operator!=(const FColour& other) const
+    {
+        return r == other.r || g == other.g || b == other.b || a == other.a;
+    }
+
+    inline constexpr bool operator!=(const IColour& other) const
+    {
+        return r == other.r || g == other.g || b == other.b || a == other.a;
+    }
 
     // Public members
 
@@ -72,6 +94,49 @@ inline constexpr IColour IGreen = {0, 255, 0, 255};
 inline constexpr IColour IBlue = {0, 0, 255, 255};
 inline constexpr IColour IPink = {255, 109, 194, 255};
 
+// Conversion functions
+
+inline constexpr FColour ToFColour(const IColour& other)
+{
+    return {(static_cast<float>(other.r) - 0.f) / (255.f - 0.f),
+            (static_cast<float>(other.g) - 0.f) / (255.f - 0.f),
+            (static_cast<float>(other.b) - 0.f) / (255.f - 0.f),
+            (static_cast<float>(other.a) - 0.f) / (255.f - 0.f)};
+}
+
+inline constexpr FColour ToIColour(const FColour& other)
+{
+    return {static_cast<float>(other.r * 255),
+            static_cast<float>(other.g * 255),
+            static_cast<float>(other.b * 255),
+            static_cast<float>(other.a * 255)};
+}
+
 } // namespace Siege
+
+namespace std
+{
+template<>
+struct ::std::hash<Siege::FColour>
+{
+    size_t operator()(const Siege::FColour& colour) const
+    {
+        size_t seed = 0;
+        Siege::Hash::HashCombine(seed, colour.r, colour.g, colour.b, colour.a);
+        return seed;
+    };
+};
+
+template<>
+struct ::std::hash<Siege::IColour>
+{
+    size_t operator()(const Siege::IColour& colour) const
+    {
+        size_t seed = 0;
+        Siege::Hash::HashCombine(seed, colour.r, colour.g, colour.b, colour.a);
+        return seed;
+    };
+};
+} // namespace std
 
 #endif // SIEGE_ENGINE_COLOUR_H

--- a/engine/utils/Colour.h
+++ b/engine/utils/Colour.h
@@ -9,39 +9,69 @@
 #ifndef SIEGE_ENGINE_COLOUR_H
 #define SIEGE_ENGINE_COLOUR_H
 
+#include <cstdint>
+#include <type_traits>
+
 namespace Siege
 {
+template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+struct Colour;
+
+typedef Colour<float> FColour;
+typedef Colour<uint8_t> IColour;
+
+template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type*>
 struct Colour
 {
-    // Public constants
-
-    static const Colour Black;
-
-    static const Colour White;
-
-    static const Colour Red;
-
-    static const Colour Green;
-
-    static const Colour Blue;
-
-    static const Colour Pink;
-
     // 'Structors
 
-    Colour() : Colour(0, 0, 0, 0) {}
+    inline constexpr Colour(T red = 0, T green = 0, T blue = 0, T alpha = 0) :
+        r {red},
+        g {green},
+        b {blue},
+        a {alpha}
+    {}
 
-    Colour(int r, int g, int b) : r(r), g(g), b(b), a(255) {}
+    inline constexpr Colour(const FColour& other) :
+        r {static_cast<T>(other.r)},
+        g {static_cast<T>(other.g)},
+        b {static_cast<T>(other.b)},
+        a {static_cast<T>(other.a)}
+    {}
 
-    Colour(int r, int g, int b, int a) : r(r), g(g), b(b), a(a) {}
+    inline constexpr Colour(const IColour& other) :
+        r {static_cast<T>(other.r)},
+        g {static_cast<T>(other.g)},
+        b {static_cast<T>(other.b)},
+        a {static_cast<T>(other.a )}
+    {}
 
     // Public members
 
-    int r;
-    int g;
-    int b;
-    int a;
+    T r {0};
+    T g {0};
+    T b {0};
+    T a {0};
 };
+
+// FColour constants
+
+inline constexpr FColour FWhite = {1.f, 1.f, 1.f, 1.f};
+inline constexpr FColour FBlack = {0.f, 0.f, 0.f, 1.f};
+inline constexpr FColour FRed = {1.f, 0.f, 0.f, 1.f};
+inline constexpr FColour FGreen = {0.f, 1.f, 0.f, 1.f};
+inline constexpr FColour FBlue = {0.f, 0.f, 1.f, 1.f};
+inline constexpr FColour FPink = {1.f, 0.427450980392, 0.760784313725, 1.f};
+
+// IColour constants
+
+inline constexpr IColour IWhite = {255, 255, 255, 255};
+inline constexpr IColour IBlack = {0, 0, 0, 255};
+inline constexpr IColour IRed = {255, 0, 0, 255};
+inline constexpr IColour IGreen = {0, 255, 0, 255};
+inline constexpr IColour IBlue = {0, 0, 255, 255};
+inline constexpr IColour IPink = {255, 109, 194, 255};
+
 } // namespace Siege
 
 #endif // SIEGE_ENGINE_COLOUR_H

--- a/examples/game/src/tools/DevConsole.cpp
+++ b/examples/game/src/tools/DevConsole.cpp
@@ -152,8 +152,8 @@ void DevConsole::OnDraw2D()
     Siege::Window* window = ServiceLocator::GetWindow();
 
     // Draw the console to the screen
-    Siege::Statics::Render().DrawRectangle2D(0, 0, window->GetWidth(), 40, Siege::Colour::Black);
-    Siege::Statics::Render().DrawText2D("~ " + inputText, 10.f, 10.f, 20.f, Siege::Colour::White);
+    Siege::Statics::Render().DrawRectangle2D(0, 0, window->GetWidth(), 40, Siege::IBlack);
+    Siege::Statics::Render().DrawText2D("~ " + inputText, 10.f, 10.f, 20.f, Siege::IWhite);
 }
 
 bool DevConsole::CheckEditorMode()

--- a/examples/game/src/tools/DevConsole.cpp
+++ b/examples/game/src/tools/DevConsole.cpp
@@ -152,8 +152,8 @@ void DevConsole::OnDraw2D()
     Siege::Window* window = ServiceLocator::GetWindow();
 
     // Draw the console to the screen
-    Siege::Statics::Render().DrawRectangle2D(0, 0, window->GetWidth(), 40, Siege::IBlack);
-    Siege::Statics::Render().DrawText2D("~ " + inputText, 10.f, 10.f, 20.f, Siege::IWhite);
+    Siege::Statics::Render().DrawRectangle2D(0, 0, window->GetWidth(), 40, Siege::IColour::Black);
+    Siege::Statics::Render().DrawText2D("~ " + inputText, 10.f, 10.f, 20.f, Siege::IColour::White);
 }
 
 bool DevConsole::CheckEditorMode()

--- a/examples/game/src/tools/EditorController.cpp
+++ b/examples/game/src/tools/EditorController.cpp
@@ -189,19 +189,19 @@ void EditorController::OnDraw2D()
         (int) screenPosition.x - Siege::Window::GetTextWidth(nameLabel, 20) / 2,
         (int) screenPosition.y,
         20,
-        Siege::IPink);
+        Siege::IColour::Pink);
     Siege::Statics::Render().DrawText2D(
         posLabel,
         (int) screenPosition.x - Siege::Window::GetTextWidth(posLabel, 18) / 2,
         (int) screenPosition.y + 20,
         18,
-        currentMode == POSITION ? BRIGHT_PINK : Siege::IPink);
+        currentMode == POSITION ? BRIGHT_PINK : Siege::IColour::Pink);
     Siege::Statics::Render().DrawText2D(
         rotLabel,
         (int) screenPosition.x - Siege::Window::GetTextWidth(posLabel, 18) / 2,
         (int) screenPosition.y + 40,
         18,
-        currentMode == ROTATION ? BRIGHT_PINK : Siege::IPink);
+        currentMode == ROTATION ? BRIGHT_PINK : Siege::IColour::Pink);
 }
 
 void EditorController::SelectEntity(Entity* entity)

--- a/examples/game/src/tools/EditorController.cpp
+++ b/examples/game/src/tools/EditorController.cpp
@@ -24,7 +24,7 @@ static float MOVE_LEVELS[] = {.01f, .1f, 1.f, 5.f, 10.f, 50.f, 100.f};
 static float ROTATE_LEVELS[] = {.01f, .1f, 1.f, 15.f, 45.f, 90.f};
 
 // Define colours
-static Siege::Colour BRIGHT_PINK(255, 5, 146);
+static Siege::IColour BRIGHT_PINK(255, 5, 146);
 
 void EditorController::OnStart()
 {
@@ -189,19 +189,19 @@ void EditorController::OnDraw2D()
         (int) screenPosition.x - Siege::Window::GetTextWidth(nameLabel, 20) / 2,
         (int) screenPosition.y,
         20,
-        Siege::Colour::Pink);
+        Siege::IPink);
     Siege::Statics::Render().DrawText2D(
         posLabel,
         (int) screenPosition.x - Siege::Window::GetTextWidth(posLabel, 18) / 2,
         (int) screenPosition.y + 20,
         18,
-        currentMode == POSITION ? BRIGHT_PINK : Siege::Colour::Pink);
+        currentMode == POSITION ? BRIGHT_PINK : Siege::IPink);
     Siege::Statics::Render().DrawText2D(
         rotLabel,
         (int) screenPosition.x - Siege::Window::GetTextWidth(posLabel, 18) / 2,
         (int) screenPosition.y + 40,
         18,
-        currentMode == ROTATION ? BRIGHT_PINK : Siege::Colour::Pink);
+        currentMode == ROTATION ? BRIGHT_PINK : Siege::IPink);
 }
 
 void EditorController::SelectEntity(Entity* entity)

--- a/examples/game/src/tools/MessageDisplay.cpp
+++ b/examples/game/src/tools/MessageDisplay.cpp
@@ -16,7 +16,7 @@ void MessageDisplay::OnDraw2D()
     // Draw the display message to the screen while the display time is valid
     if (displayTime > 0.f)
     {
-        Siege::Statics::Render().DrawText2D(displayMessage, 10, 10, 20, Siege::Colour::Pink);
+        Siege::Statics::Render().DrawText2D(displayMessage, 10, 10, 20, Siege::IPink);
         displayTime -= 0.1f;
     }
 }

--- a/examples/game/src/tools/MessageDisplay.cpp
+++ b/examples/game/src/tools/MessageDisplay.cpp
@@ -16,7 +16,7 @@ void MessageDisplay::OnDraw2D()
     // Draw the display message to the screen while the display time is valid
     if (displayTime > 0.f)
     {
-        Siege::Statics::Render().DrawText2D(displayMessage, 10, 10, 20, Siege::IPink);
+        Siege::Statics::Render().DrawText2D(displayMessage, 10, 10, 20, Siege::IColour::Pink);
         displayTime -= 0.1f;
     }
 }

--- a/examples/render/src/GameObject.cpp
+++ b/examples/render/src/GameObject.cpp
@@ -14,7 +14,7 @@ GameObject::GameObject(Siege::Model* model) : model {model} {}
 
 GameObject::~GameObject() {}
 
-void GameObject::SetColor(const Siege::Vec3& newColor)
+void GameObject::SetColour(const Siege::IColour& newColor)
 {
     fillColor = newColor;
 }

--- a/examples/render/src/GameObject.h
+++ b/examples/render/src/GameObject.h
@@ -31,7 +31,7 @@ public:
 
     ~GameObject();
 
-    Siege::Vec3& GetColor()
+    Siege::IColour& GetColor()
     {
         return fillColor;
     }
@@ -93,7 +93,7 @@ public:
         return transform.GetRotation().z;
     }
 
-    void SetColor(const Siege::Vec3& newColor);
+    void SetColour(const Siege::IColour& newColor);
     void SetScale(const Siege::Vec3& newScale);
     void SetPosition(const Siege::Vec3& newPos);
     void SetRotation(const Siege::Vec3& rotation);
@@ -110,6 +110,6 @@ private:
 
     Siege::Xform transform {};
     Siege::Model* model;
-    Siege::Vec3 fillColor {};
+    Siege::IColour fillColor {};
 };
 #endif

--- a/examples/render/src/main.cpp
+++ b/examples/render/src/main.cpp
@@ -35,9 +35,9 @@
 static const constexpr int WIDTH = 800;
 static const constexpr int HEIGHT = 600;
 
-Siege::Vertex2D triangleVerts[] = {{{0.f, -1.f}, {1.f, 0.f, 0.f}},
-                                   {{1.f, 1.f}, {0.f, 1.f, 0.f}},
-                                   {{-1.f, 1.f}, {0.f, 0.f, 1.f}}};
+Siege::Vertex2D triangleVerts[] = {{{0.f, -1.f}, {1.f, 0.f, 0.f, 1.f}},
+                                   {{1.f, 1.f}, {0.f, 1.f, 0.f, 1.f}},
+                                   {{-1.f, 1.f}, {0.f, 0.f, 1.f, 1.f}}};
 
 Siege::Mesh::MeshData triangleMeshData {
     sizeof(Siege::Vertex2D),
@@ -48,10 +48,10 @@ Siege::Mesh::MeshData triangleMeshData {
 };
 
 Siege::Vertex2D squareVerts[] = {
-    {{1.f, 1.f}, {1.f, 0.f, 0.f}}, // top right
-    {{1.f, -1.f}, {1.f, 0.f, 0.f}}, // bottom right
-    {{-1.f, -1.f}, {1.f, 0.f, 0.f}}, // bottom left
-    {{-1.f, 1.f}, {1.f, 0.f, 0.f}}, // top left
+    {{1.f, 1.f}, {1.f, 0.f, 0.f, 1.f}}, // top right
+    {{1.f, -1.f}, {1.f, 0.f, 0.f, 1.f}}, // bottom right
+    {{-1.f, -1.f}, {1.f, 0.f, 0.f, 1.f}}, // bottom left
+    {{-1.f, 1.f}, {1.f, 0.f, 0.f, 1.f}}, // top left
 };
 
 uint32_t squareIndices[] = {0, 1, 3, 1, 2, 3};
@@ -81,7 +81,7 @@ int main()
                                     .FromVertexShader("assets/shaders/simpleShader.vert.spv")
                                     .WithVertexBinding(Shader::VertexBinding()
                                                            .AddFloatVec3Attribute()
-                                                           .AddFloatVec3Attribute()
+                                                           .AddFloatVec4Attribute()
                                                            .AddFloatVec3Attribute()
                                                            .AddFloatVec2Attribute())
                                     .WithTransform3DStorage(0, 1000)
@@ -96,7 +96,7 @@ int main()
         Shader::Builder()
             .FromVertexShader("assets/shaders/simpleShader2D.vert.spv")
             .WithVertexBinding(
-                Shader::VertexBinding().AddFloatVec2Attribute().AddFloatVec3Attribute())
+                Shader::VertexBinding().AddFloatVec2Attribute().AddFloatVec4Attribute())
             .WithTransform2DStorage(0, 1000)
             .WithGlobalData2DUniform()
             .Build(),
@@ -133,16 +133,16 @@ int main()
 
     objects3D[0].SetPosition({0.f, -.5f, 0.f});
     objects3D[0].SetScale({.5f, .5f, .5f});
-    objects3D[0].SetColor({.5f, 0.f, 0.f});
+    objects3D[0].SetColour({128, 0, 0, 255});
 
     objects3D[1].SetPosition({0.f, 0.f, 0.f});
     objects3D[1].SetScale({3.f, 3.f, 0.1f});
-    objects3D[1].SetColor({.5f, 0.f, 0.f});
+    objects3D[1].SetColour({128, 0, 0, 255});
     objects3D[1].SetRotationX(1.570796f);
 
     objects3D[2].SetPosition({0.f, -1.f, 0.f});
     objects3D[2].SetScale({2.f, 2.f, 2.f});
-    objects3D[2].SetColor({.5f, 0.f, 0.f});
+    objects3D[2].SetColour({128, 0, 0, 255});
 
     objects2D[0].SetPosition2D({1.5f, -1.f});
     objects2D[0].SetScale2D({.5f, 0.5f});
@@ -203,13 +203,13 @@ int main()
         // TODO(Aryeh): This will eventually need to take in multiple lights.
         Siege::Renderer3D::DrawPointLight({0.0f, -1.f, -1.5f},
                                           0.05f,
-                                          {1.f, 0.f, 0.f, alpha},
-                                          {1.f, 1.f, 1.f, .02f});
+                                          {255, 0, 0, (uint8_t) (alpha * 255.f)},
+                                          {0, 0, 255, 5});
 
-        Siege::Renderer3D::DrawBillboard({-1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
-        Siege::Renderer3D::DrawBillboard({1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});
+        Siege::Renderer3D::DrawBillboard({-1.f, -2.5f, 0.f}, {1.f, 1.f}, {255, 255, 255, 255});
+        Siege::Renderer3D::DrawBillboard({1.f, -2.5f, 0.f}, {1.f, 1.f}, {255, 0, 0, 255});
 
-        Siege::Renderer3D::DrawLine({0.0f, -1.f, -1.5f}, {0.f, -1.f, 0.f}, {1.f, 1.f, 1.f, 1.f});
+        Siege::Renderer3D::DrawLine({0.f, -1.f, -1.5f}, {0.f, -1.f, 0.f}, {255, 255, 255, 255});
 
         for (auto it = objects2D.CreateFIterator(); it; ++it)
         {

--- a/tests/utils/test_Colour.cpp
+++ b/tests/utils/test_Colour.cpp
@@ -17,20 +17,20 @@ UTEST(test_FColour, CreateFColour)
 {
     FColour colour = {255.f, 1.f, 0.4f};
 
-    ASSERT_EQ(colour.r, 255.f);
-    ASSERT_EQ(colour.g, 1.f);
-    ASSERT_EQ(colour.b, 0.4f);
-    ASSERT_EQ(colour.a, 0.f);
+    ASSERT_EQ(255.f, colour.r);
+    ASSERT_EQ(1.f, colour.g);
+    ASSERT_EQ(0.4f, colour.b);
+    ASSERT_EQ(0.f, colour.a);
 }
 
 UTEST(test_FColour, CreateConstexprFColour)
 {
     constexpr FColour colour = {255.f, 1.f, 0.4f, 0.f};
 
-    ASSERT_EQ(colour.r, 255.f);
-    ASSERT_EQ(colour.g, 1.f);
-    ASSERT_EQ(colour.b, 0.4f);
-    ASSERT_EQ(colour.a, 0.f);
+    ASSERT_EQ(255.f, colour.r);
+    ASSERT_EQ(1.f, colour.g);
+    ASSERT_EQ(0.4f, colour.b);
+    ASSERT_EQ(0.f, colour.a);
 }
 
 UTEST(test_FColour, CreateFColourFromIColour)
@@ -39,10 +39,10 @@ UTEST(test_FColour, CreateFColourFromIColour)
 
     FColour fColour = colour;
 
-    ASSERT_EQ(fColour.r, 255.f);
-    ASSERT_EQ(fColour.g, 1.f);
-    ASSERT_EQ(fColour.b, 26.f);
-    ASSERT_EQ(fColour.a, 0.f);
+    ASSERT_EQ(255.f, fColour.r);
+    ASSERT_EQ(1.f, fColour.g);
+    ASSERT_EQ(26.f, fColour.b);
+    ASSERT_EQ(0.f, fColour.a);
 }
 
 UTEST(test_FColour, CreateIColourFromFColour)
@@ -51,8 +51,32 @@ UTEST(test_FColour, CreateIColourFromFColour)
 
     IColour fColour = colour;
 
-    ASSERT_EQ(fColour.r, 255);
-    ASSERT_EQ(fColour.g, 1);
-    ASSERT_EQ(fColour.b, 26);
-    ASSERT_EQ(fColour.a, 0);
+    ASSERT_EQ(255, fColour.r);
+    ASSERT_EQ(1, fColour.g);
+    ASSERT_EQ(26, fColour.b);
+    ASSERT_EQ(0, fColour.a);
+}
+
+UTEST(test_FColour, ConvertFColourToIColour)
+{
+    constexpr FColour colour = {1.f, 0.f, .2f, .5f};
+
+    IColour iColour = Siege::ToIColour(colour);
+
+    ASSERT_EQ(255, iColour.r);
+    ASSERT_EQ(0, iColour.g);
+    ASSERT_EQ(51, iColour.b);
+    ASSERT_EQ(127, iColour.a);
+}
+
+UTEST(test_FColour, ConvertIColourToFColour)
+{
+    constexpr IColour colour = {255, 0, 51, 127};
+
+    FColour fColour = Siege::ToFColour(colour);
+
+    ASSERT_EQ(1.f, fColour.r);
+    ASSERT_EQ(0.f, fColour.g);
+    ASSERT_EQ(.2f, fColour.b);
+    ASSERT_EQ(.498039216f, fColour.a);
 }

--- a/tests/utils/test_Colour.cpp
+++ b/tests/utils/test_Colour.cpp
@@ -1,0 +1,58 @@
+//
+//
+//  Copyright (c) 2022 Jonathan Moallem (@J-Mo63) & Aryeh Zinn (@Raelr)
+//
+//  This code is released under an unmodified zlib license.
+//  For conditions of distribution and use, please see:
+//      https://opensource.org/licenses/Zlib
+//
+
+#include <utest.h>
+#include <utils/Colour.h>
+
+using Siege::FColour;
+using Siege::IColour;
+
+UTEST(test_FColour, CreateFColour)
+{
+    FColour colour = {255.f, 1.f, 0.4f};
+
+    ASSERT_EQ(colour.r, 255.f);
+    ASSERT_EQ(colour.g, 1.f);
+    ASSERT_EQ(colour.b, 0.4f);
+    ASSERT_EQ(colour.a, 0.f);
+}
+
+UTEST(test_FColour, CreateConstexprFColour)
+{
+    constexpr FColour colour = {255.f, 1.f, 0.4f, 0.f};
+
+    ASSERT_EQ(colour.r, 255.f);
+    ASSERT_EQ(colour.g, 1.f);
+    ASSERT_EQ(colour.b, 0.4f);
+    ASSERT_EQ(colour.a, 0.f);
+}
+
+UTEST(test_FColour, CreateFColourFromIColour)
+{
+    constexpr IColour colour = {255, 1, 26, 0};
+
+    FColour fColour = colour;
+
+    ASSERT_EQ(fColour.r, 255.f);
+    ASSERT_EQ(fColour.g, 1.f);
+    ASSERT_EQ(fColour.b, 26.f);
+    ASSERT_EQ(fColour.a, 0.f);
+}
+
+UTEST(test_FColour, CreateIColourFromFColour)
+{
+    constexpr FColour colour = {255.f, 1.f, 26.f, 0.f};
+
+    IColour fColour = colour;
+
+    ASSERT_EQ(fColour.r, 255);
+    ASSERT_EQ(fColour.g, 1);
+    ASSERT_EQ(fColour.b, 26);
+    ASSERT_EQ(fColour.a, 0);
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of what this PR does and how it can be tested below (provide screenshots/gifs if relevant) -->
Adds two Colour types: `FColour` and `IColour`. The `FColour` type is a Colour struct which stores all channels as floats, while the `IColour` type stores them as unsigned 8-bit integers. 

<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added Vulkan render delegate")
- [x] linked to its related issue
- [x] assigned a reviewer from the team
- [x] labelled appropriately

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] tested in a packaged state using the `package` targets
- [x] pulled to the reviewer's machine and reasonably tested

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
