### PR TITLE
Implemented scoped defer utility

### DIFF
--- a/engine/render/renderer/platform/vulkan/Texture2D.cpp
+++ b/engine/render/renderer/platform/vulkan/Texture2D.cpp
@@ -15,6 +15,7 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
+#include <utils/Defer.h>
 #include <utils/Logging.h>
 
 namespace Siege::Vulkan
@@ -73,6 +74,7 @@ void Texture2D::LoadFromFile(const char* filePath)
     uint64_t imageSize = texWidth * texHeight * 4;
 
     uint8_t* pixelPtr = new uint8_t[imageSize];
+    defer([pixelPtr] { delete[] pixelPtr; });
 
     // Set the image to 0 so that we get no garbage data in the pixel array
     memset(pixelPtr, 0, imageSize);
@@ -102,8 +104,6 @@ void Texture2D::LoadFromFile(const char* filePath)
     image.CopyBuffer(stagingBuffer.buffer);
 
     Buffer::DestroyBuffer(stagingBuffer);
-
-    delete[] pixelPtr;
 }
 
 void Texture2D::LoadTexture(const uint8_t* pixels, size_t size, uint32_t width, uint32_t height)

--- a/engine/utils/Defer.h
+++ b/engine/utils/Defer.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2023 Jonathan Moallem (@J-Mo63) & Aryeh Zinn (@Raelr)
+//
+// This code is released under an unmodified zlib license.
+// For conditions of distribution and use, please see:
+//     https://opensource.org/licenses/Zlib
+//
+
+#ifndef SIEGE_ENGINE_DEFER_H
+#define SIEGE_ENGINE_DEFER_H
+
+#include <functional>
+
+#include "Macros.h"
+
+namespace Siege
+{
+
+/**
+ * A basic deferred call object implementation that executes its provided callable on scope exit.
+ */
+struct ScopedDefer
+{
+    /**
+     * Explicitly deleted zero-param constructor
+     */
+    ScopedDefer() = delete;
+
+    /**
+     * Constructor, specifying owned callable
+     * @param callable - the void-returning, parameterless callable to execute
+     */
+    explicit ScopedDefer(const std::function<void()>& callable) : callable(callable) {}
+
+    /**
+     * Destructor, executing callable on scope exit
+     */
+    ~ScopedDefer()
+    {
+        callable();
+    }
+
+    /**
+     * Held void-retuning, parameterless callable
+     */
+    std::function<void()> callable;
+};
+
+#define _DEFER_VAR_NAME CONCAT_SYMBOL(_defer_, __COUNTER__)
+#define defer(callable) auto _DEFER_VAR_NAME = Siege::ScopedDefer(callable)
+
+} // namespace Siege
+
+#endif // SIEGE_ENGINE_DEFER_H

--- a/tests/utils/test_Defer.cpp
+++ b/tests/utils/test_Defer.cpp
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2022 Jonathan Moallem (@J-Mo63) & Aryeh Zinn (@Raelr)
+//
+// This code is released under an unmodified zlib license.
+// For conditions of distribution and use, please see:
+//     https://opensource.org/licenses/Zlib
+//
+
+#include <utest.h>
+#include <utils/Defer.h>
+
+UTEST(test_Defer, BasicScopeDeferModify)
+{
+    bool a = true;
+    {
+        ASSERT_TRUE(a);
+        defer([&a] { a = false; });
+        a = true;
+        ASSERT_TRUE(a);
+    }
+    ASSERT_FALSE(a);
+}
+
+UTEST(test_Defer, BasicScopeDeferDeletion)
+{
+    auto* a = new bool;
+    {
+        ASSERT_TRUE(a);
+        defer([&a] {
+            delete a;
+            a = nullptr;
+        });
+        ASSERT_TRUE(a);
+    }
+    ASSERT_FALSE(a);
+}
+
+UTEST(test_Defer, LoopScopeDeferModify)
+{
+    bool a = true;
+    for (uint8_t i = 0; i < 3; ++i)
+    {
+        ASSERT_TRUE(a);
+        defer([&a] { a = true; });
+        a = false;
+        ASSERT_FALSE(a);
+    }
+    ASSERT_TRUE(a);
+}


### PR DESCRIPTION
### Description
<!-- Provide a brief description of what this PR does and how it can be tested below (provide screenshots/gifs if relevant) -->
This PR introduces a basic `defer` mechanism to the engine utilities, similar to GoLang's keyword of the same name. As demonstrated in the provided unit tests, the scoped defer will execute its provided callable on scope exit e.g.:
```cpp
void func()
{
    std::out << "outer scope start\n";
    bool* a = new bool;
    defer([a] { delete a; std::out << "!!! cleaned up heap var\n"; });
    {
        std::out << "inner scope start\n";
        defer([] { std::out << "!!! inner scope defer\n"; });
        std::out << "inner scope end\n";
    }
    if (a)
    {
        std::out << "early return\n";
        return;
    }
    std::out << "outer scope end\n";
}
```
which would produce the following output:
```console
outer scope start
inner scope start
inner scope end
!!! inner scope defer
early return **OR** outer scope end **(depending on value of a)**
!!! cleaned up heap var
```
The key takeaway from this is that whether the program performs an early return or not, the heap variable will get cleaned up on function exit.


<!-- DO NOT delete the checklist below, make sure to complete each step after publishing the PR -->
### The PR has been...
- [x] provided a reasonable name that is not just the branch name (e.g "Added Vulkan render delegate")
- [x] linked to its related issue
- [x] assigned a reviewer from the team
- [x] labelled appropriately

### The code has been...
- [x] made mergable and free of conflicts in relation to `master` *(according to GitHub)*
- [x] tested in a packaged state using the `package` targets
- [x] pulled to the reviewer's machine and reasonably tested

<!-- Any questions related to the PR should be added as comments below, tagging a specific team member -->
